### PR TITLE
[Lab5] Adding TX errors monitor: MonitorTxOrch

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -98,7 +98,8 @@ orchagent_SOURCES = \
             bfdorch.cpp \
             srv6orch.cpp \
             response_publisher.cpp \
-            nvgreorch.cpp
+            nvgreorch.cpp \
+            monitortxorch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp flex_counter/flow_counter_handler.cpp flex_counter/flowcounterrouteorch.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/monitortxorch.cpp
+++ b/orchagent/monitortxorch.cpp
@@ -1,0 +1,182 @@
+#include "monitortxorch.h"
+#include "select.h"
+#include <inttypes.h>
+#include <unordered_map>
+#include "converter.h"
+
+extern PortsOrch *gPortsOrch;
+
+#define TX_ERRORS_COUNTER_NAME "SAI_PORT_STAT_IF_OUT_ERRORS"
+
+#define TX_ERRORS_OK_STATE "OK"
+#define TX_ERRORS_NOT_OK_STATE "NOT OK"
+
+#define CONFIG_KEY_NAME "config"
+#define THRESHOLD_FIELD_NAME "threshold"
+#define DURATION_FIELD_NAME "duration"
+
+
+
+MonitorTxOrch& MonitorTxOrch::getInstance(TableConnector TxErrorsMonitorTableConnetctor)
+{
+    SWSS_LOG_ENTER();
+    static MonitorTxOrch *monitorTxOrch = new MonitorTxOrch(TxErrorsMonitorTableConnetctor);
+    return *monitorTxOrch;
+}
+
+
+MonitorTxOrch::MonitorTxOrch(TableConnector TxErrorsMonitorTableConnetctor):
+    Orch(TxErrorsMonitorTableConnetctor.first, TxErrorsMonitorTableConnetctor.second),
+	m_countersDb(new DBConnector("COUNTERS_DB", 0)),
+	m_countersTable(new Table(m_countersDb.get(), COUNTERS_TABLE)),
+	m_stateDb(new DBConnector("STATE_DB", 0)),
+	m_stateTable(new Table(m_stateDb.get(), STATE_TX_ERROR_TABLE_NAME))
+{
+    SWSS_LOG_ENTER();
+
+    m_cfgTxTbl = unique_ptr<Table>(new Table(TxErrorsMonitorTableConnetctor.first, TxErrorsMonitorTableConnetctor.second));
+    initCfgTxTbl();
+
+    auto interv = timespec { .tv_sec = m_duration, .tv_nsec = 0 };
+    m_timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(m_timer, this, "MC_TX_POLL");
+    Orch::addExecutor(executor);
+    m_timer->start();
+}
+
+
+MonitorTxOrch::~MonitorTxOrch(void)
+{
+    SWSS_LOG_ENTER();
+}
+
+
+void MonitorTxOrch::initCfgTxTbl()
+{
+    /*
+     table name: "TX_ERROR_MONITOR" "config"
+     "duration"
+     <duration value>
+     "threshold"
+     <threshold value>
+     */
+    SWSS_LOG_ENTER();
+
+    vector<FieldValueTuple> fvs;
+    fvs.emplace_back(DURATION_FIELD_NAME, std::to_string(m_duration));
+    fvs.emplace_back(THRESHOLD_FIELD_NAME, std::to_string(m_threshold));
+    m_cfgTxTbl->set(CONFIG_KEY_NAME, fvs);
+}
+
+
+void MonitorTxOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    std::unordered_map<std::string, std::string> txErrorStates;
+    std::string txErrorsCounterStr;
+
+    auto allPorts = gPortsOrch->getAllPorts();
+    for (auto &it: allPorts)
+    {
+        Port port = it.second;
+        string currInterface = port.m_alias.c_str();
+
+		if (!m_countersTable->hget(sai_serialize_object_id(port.m_port_id), TX_ERRORS_COUNTER_NAME, txErrorsCounterStr))
+		{
+			SWSS_LOG_NOTICE("COULD NOT FIND PORT'S TX_ERRORS");
+			continue;
+		}
+		uint32_t currValue = to_uint<uint32_t>(txErrorsCounterStr);
+
+        updateCurrentStateForPort(currInterface, currValue, txErrorStates);
+
+        lastTxErrorsPerPortStats[currInterface] = currValue;
+    }
+    updateStateDb(txErrorStates);
+}
+
+
+void MonitorTxOrch::updateCurrentStateForPort(string currInterface, uint32_t currValue, std::unordered_map<std::string, std::string>& txErrorStates){
+	uint32_t lastValue = lastTxErrorsPerPortStats[currInterface];
+	if(currValue > lastValue){
+		if(currValue - lastValue > m_threshold)
+			txErrorStates[currInterface] = TX_ERRORS_NOT_OK_STATE;
+		else
+			txErrorStates[currInterface] = TX_ERRORS_OK_STATE;
+	}
+	else{
+		txErrorStates[currInterface] = TX_ERRORS_OK_STATE;
+	}
+}
+
+
+void MonitorTxOrch::updateStateDb(std::unordered_map<std::string, std::string>& txErrorStates){
+
+    for (auto const& entry : txErrorStates){
+        FieldValueTuple currTxState(entry.first, entry.second);
+        vector<FieldValueTuple> fields;
+        fields.push_back(currTxState);
+        m_stateTable->set("", fields);
+        fields.clear();
+    }
+}
+
+
+void MonitorTxOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = consumer.m_toSync.begin();
+	while (it != consumer.m_toSync.end())
+	{
+		auto &event = it->second;
+		handleEvent(event);
+		consumer.m_toSync.erase(it++);
+	}
+
+}
+
+
+void MonitorTxOrch::handleEvent(KeyOpFieldsValuesTuple event){
+	string key = kfvKey(event);
+	string op = kfvOp(event);
+	vector<FieldValueTuple> fvs = kfvFieldsValues(event);
+
+	if(key == CONFIG_KEY_NAME && op == SET_COMMAND){
+		HandleConfigUpdate(fvs);
+	}
+	else{
+		SWSS_LOG_WARN("Unexpected event: op = %s; key = %s" ,op.c_str(), key.c_str());
+	}
+}
+
+
+void MonitorTxOrch::HandleConfigUpdate(vector<FieldValueTuple> fvs){
+	for (auto fv : fvs){
+		string field = fvField(fv);
+		string value = fvValue(fv);
+
+		if(field == THRESHOLD_FIELD_NAME){
+			uint32_t newThreshold = to_uint<uint32_t>(value);
+			if(newThreshold != m_threshold){
+				m_threshold = to_uint<uint32_t>(value);
+				SWSS_LOG_NOTICE("Threshold set to: %s",value.c_str());
+			}
+		}
+		else{
+			if(field == DURATION_FIELD_NAME){
+				uint32_t newDuration = to_uint<uint32_t>(value);
+				if(m_duration != newDuration){
+					m_duration = newDuration;
+					SWSS_LOG_NOTICE("Duration set to: %s",value.c_str());
+					auto interv = timespec { .tv_sec = m_duration, .tv_nsec = 0 };
+					m_timer->setInterval(interv);
+					m_timer->reset();
+				}
+			}
+			else
+				SWSS_LOG_WARN("Unexpected field for set command: %s", field.c_str());
+		}
+	}
+}

--- a/orchagent/monitortxorch.h
+++ b/orchagent/monitortxorch.h
@@ -1,0 +1,41 @@
+#ifndef MONITORTX_ORCH_H
+#define MONITORTX_ORCH_H
+
+#include "orch.h"
+#include "port.h"
+#include "timer.h"
+#include "portsorch.h"
+#include <array>
+
+
+class MonitorTxOrch: public Orch
+{
+public:
+    static MonitorTxOrch& getInstance(TableConnector configDbTableConnetctor);
+    virtual void doTask(swss::SelectableTimer &timer);
+    virtual void doTask(Consumer &consumer);
+
+private:
+    std::unique_ptr<swss::Table> m_cfgTxTbl;
+	std::shared_ptr<swss::DBConnector> m_countersDb = nullptr;
+	std::shared_ptr<swss::Table> m_countersTable = nullptr;
+	std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;
+	std::shared_ptr<swss::Table> m_stateTable = nullptr;
+    uint32_t m_threshold = 51;
+    uint32_t m_duration = 15;
+    std::unordered_map<std::string, uint32_t> lastTxErrorsPerPortStats;
+    SelectableTimer* m_timer = nullptr;
+
+    MonitorTxOrch(TableConnector configDbTableConnetctor);
+    virtual ~MonitorTxOrch(void);
+
+    void initCfgTxTbl();
+
+    void updateCurrentStateForPort(string currInterface, uint32_t currValue, std::unordered_map<std::string, std::string>& txState);
+    void updateStateDb(std::unordered_map<std::string, std::string>& txState);
+
+    void handleEvent(KeyOpFieldsValuesTuple event);
+    void HandleConfigUpdate(vector<FieldValueTuple> fvs);
+};
+
+#endif

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -27,6 +27,11 @@ extern void syncd_apply_view();
  * Global orch daemon variables
  */
 PortsOrch *gPortsOrch;
+
+
+MonitorTxOrch *gMonitorTxOrch;
+
+
 FabricPortsOrch *gFabricPortsOrch;
 FdbOrch *gFdbOrch;
 IntfsOrch *gIntfsOrch;
@@ -344,6 +349,16 @@ bool OrchDaemon::init()
 
     gNhgMapOrch = new NhgMapOrch(m_applDb, APP_FC_TO_NHG_INDEX_MAP_TABLE_NAME);
 
+
+
+
+    TableConnector txErrorConfigTableConnector(m_configDb, CFG_TX_ERROR_MONITOR_TABLE_NAME);
+    gMonitorTxOrch = &MonitorTxOrch::getInstance(txErrorConfigTableConnector);
+
+
+
+
+
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.
@@ -352,7 +367,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, tunnel_decap_orch, sflow_orch, gDebugCounterOrch, gMacsecOrch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, tunnel_decap_orch, sflow_orch, gDebugCounterOrch, gMacsecOrch, gBfdOrch, gSrv6Orch, mux_orch, mux_cb_orch, gMonitorTxOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)
@@ -647,6 +662,7 @@ bool OrchDaemon::init()
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
+//    m_orchList.push_back(&MonitorTxOrch::getInstance(m_configDb));
 
     vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
     gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -27,11 +27,7 @@ extern void syncd_apply_view();
  * Global orch daemon variables
  */
 PortsOrch *gPortsOrch;
-
-
 MonitorTxOrch *gMonitorTxOrch;
-
-
 FabricPortsOrch *gFabricPortsOrch;
 FdbOrch *gFdbOrch;
 IntfsOrch *gIntfsOrch;
@@ -349,15 +345,8 @@ bool OrchDaemon::init()
 
     gNhgMapOrch = new NhgMapOrch(m_applDb, APP_FC_TO_NHG_INDEX_MAP_TABLE_NAME);
 
-
-
-
     TableConnector txErrorConfigTableConnector(m_configDb, CFG_TX_ERROR_MONITOR_TABLE_NAME);
     gMonitorTxOrch = &MonitorTxOrch::getInstance(txErrorConfigTableConnector);
-
-
-
-
 
     /*
      * The order of the orch list is important for state restore of warm start and
@@ -662,7 +651,6 @@ bool OrchDaemon::init()
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
-//    m_orchList.push_back(&MonitorTxOrch::getInstance(m_configDb));
 
     vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
     gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -30,6 +30,7 @@
 #include "vxlanorch.h"
 #include "vnetorch.h"
 #include "countercheckorch.h"
+#include "monitortxorch.h"
 #include "flexcounterorch.h"
 #include "watermarkorch.h"
 #include "policerorch.h"

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -103,6 +103,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/bfdorch.cpp \
                 $(top_srcdir)/orchagent/srv6orch.cpp \
                 $(top_srcdir)/orchagent/nvgreorch.cpp \
+                $(top_srcdir)/orchagent/monitortxorch.cpp \
                 $(top_srcdir)/cfgmgr/portmgr.cpp \
                 $(top_srcdir)/cfgmgr/buffermgrdyn.cpp
 


### PR DESCRIPTION
**What I did**
Added a new orchagent, called MonitorTxOrch, to monitor TX errors and tag every port of the switch as "OK" or "NOT OK": if TX errors on a certain port exceed a configurable threshold in a configurable time period, this port will be tagged "NOT OK".

**Why I did it**
In order to get the tx errors status for each port of the switch.

**How I verified it**
enter the following CLI commands:

test 1:
1. "show txstate summary"
2. choose one oid of port with the status "ok"
3. stop the counters:
       "counterpoll port disable"
4. set the threshold to 100:
      "config txargs_threshold 100"
4. set the tx counter of the port to be above threshold:
       "redis-cli -n 2 HSET COUNTERS:oid: ... SAI_PORT_STAT_IF_OUT_ERRORS "200""
5. verify that the status of the port changes to NOT OK:
       "show txstate summary"


test 2:
1. "show txstate summary"
2. choose one oid of port with the status "ok"
3. stop the counters:
       "counterpoll port disable"
4. set the threshold to 50:
"config txargs_threshold 50"
5. set the tx counter of the port to be lower than the threshold:
redis-cli -n 2 HSET COUNTERS:oid: ... SAI_PORT_STAT_IF_OUT_ERRORS "20"
6. verify that the status of the port is still OK:
"show txstate summary"